### PR TITLE
Skip copying specified files with an exclusion pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3] 2026-04-01
+
+### Added
+- Support for skipping copying for FASTQ files matching a user-specified pattern (#11)
+
+
 ## [0.2] 2025-12-15
 
 ### Added

--- a/ezfastq/api.py
+++ b/ezfastq/api.py
@@ -21,9 +21,15 @@ def copy(
     subdir="seq",
     link=False,
     verbose=False,
+    excl_pattern=None,
 ):
     copier = FastqCopier.from_dir(
-        sample_name_map, seq_path, prefix=prefix, pair_mode=pair_mode, link=link
+        sample_name_map,
+        seq_path,
+        prefix=prefix,
+        pair_mode=pair_mode,
+        link=link,
+        excl_pattern=excl_pattern,
     )
     copier.copy_files(workdir / subdir)
     copier.print_copy_log()

--- a/ezfastq/cli.py
+++ b/ezfastq/cli.py
@@ -29,6 +29,7 @@ def main(arglist=None):
         subdir=args.subdir,
         link=args.link,
         verbose=args.verbose,
+        excl_pattern=args.exclude,
     )
 
 
@@ -112,6 +113,14 @@ def get_parser():
         "--link",
         action="store_true",
         help="symbolically link files rather than copying; only supported for gzip-compressed files",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        metavar="REGEX",
+        type=str,
+        default=None,
+        help="skip copying FASTQ files containing the given substring",
     )
     parser.add_argument(
         "-V",

--- a/ezfastq/cli.py
+++ b/ezfastq/cli.py
@@ -13,7 +13,6 @@ from .pair import PairMode
 from argparse import ArgumentParser
 from importlib.metadata import version
 from pathlib import Path
-from rich.text import Text
 from rich_argparse import RawDescriptionRichHelpFormatter
 from shutil import get_terminal_size
 
@@ -54,7 +53,8 @@ def get_parser():
     ezfastq /path/to/fastqs/ s1:Sample1 s2:Sample2 s3:Sample3
     ezfastq /path/to/fastqs/ samplenames.txt
     ezfastq /path/to/fastqs/ samplenames.txt --workdir /path/to/projectdir/ --subdir seq/Run01/
-    ezfastq /path/to/fastqs/ samplenames.txt --pair-mode 2[/dim]
+    ezfastq /path/to/fastqs/ samplenames.txt --pair-mode 2
+    ezfastq /path/to/fastqs/ samplenames.txt --exclude '\\[r,R]2'[/dim]
 """
     width = min(99, get_terminal_size().columns - 2)
     parser = ArgumentParser(

--- a/ezfastq/copier.py
+++ b/ezfastq/copier.py
@@ -112,7 +112,7 @@ class FastqCopier:
         return max(len(sample) for sample in self.sample_name_map.keys())
 
     def __len__(self):
-        return sum(len(fqfiles) for fqfiles in self.file_map.values())
+        return len([fastq for fastq in self])
 
     def __iter__(self):
         for sample_name, fqfiles in sorted(self.file_map.items()):

--- a/ezfastq/copier.py
+++ b/ezfastq/copier.py
@@ -24,9 +24,10 @@ from rich.progress import (
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
+import re
 from rich.syntax import Syntax
 import sys
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -42,15 +43,24 @@ class FastqCopier:
     file_map: SampleFastqMap
     prefix: str = ""
     link: bool = False
+    excl_pattern: Optional[str] = None
 
     @classmethod
     def from_dir(
-        cls, sample_name_map, data_path, prefix="", pair_mode=PairMode.Unspecified, link=False
+        cls,
+        sample_name_map,
+        data_path,
+        prefix="",
+        pair_mode=PairMode.Unspecified,
+        link=False,
+        excl_pattern=None,
     ):
         copied_files = list()
         skipped_files = list()
         file_map = SampleFastqMap.new(sample_name_map.keys(), data_path, pair_mode=pair_mode)
-        copier = cls(sample_name_map, copied_files, skipped_files, file_map, prefix, link)
+        copier = cls(
+            sample_name_map, copied_files, skipped_files, file_map, prefix, link, excl_pattern
+        )
         return copier
 
     def copy_files(self, destination):
@@ -108,6 +118,8 @@ class FastqCopier:
         for sample_name, fqfiles in sorted(self.file_map.items()):
             for n, fqfile in enumerate(fqfiles, 1):
                 source_path = Path(fqfile).absolute()
+                if self.excl_pattern and re.search(self.excl_pattern, source_path.name):
+                    continue
                 read = 0 if len(fqfiles) == 1 else n
                 new_name = self.sample_name_map[sample_name]
                 yield FastqFile(source_path, new_name, read, self.prefix)

--- a/ezfastq/tests/test_cli.py
+++ b/ezfastq/tests/test_cli.py
@@ -58,6 +58,14 @@ def test_link(tmp_path):
     assert "SkippedFiles" not in log_data
 
 
+def test_exclusion(tmp_path):
+    seq_path = files("ezfastq") / "tests" / "data" / "flat"
+    arglist = [seq_path, "test1", "test2", "--workdir", tmp_path, "--link", "--exclude", "R2"]
+    cli.main(arglist)
+    assert len(list((tmp_path / "seq").glob("*_R1.fastq.gz"))) == 2
+    assert len(list((tmp_path / "seq").glob("*_R2.fastq.gz"))) == 0
+
+
 def test_copy_subdir(tmp_path):
     seq_path = files("ezfastq") / "tests" / "data" / "flat"
     arglist = [seq_path, "test1", "test2", "--workdir", tmp_path, "--subdir", "seq/PROJa/RUNb"]

--- a/ezfastq/tests/test_copier.py
+++ b/ezfastq/tests/test_copier.py
@@ -85,6 +85,13 @@ def test_copier_link_error(tmp_path):
         copier.copy_files(tmp_path)
 
 
+def test_copier_exclusion(tmp_path):
+    sample_names = NameMap.from_arglist(["test1", "test2"])
+    copier = FastqCopier.from_dir(sample_names, SEQ_PATH_1, link=True, excl_pattern="R2")
+    copier.copy_files(tmp_path)
+    assert len(list(tmp_path.glob("*.fastq.gz"))) == 2
+
+
 def test_copier_prefix(tmp_path):
     sample_names = NameMap.from_arglist(["test2", "test3"])
     copier = FastqCopier.from_dir(sample_names, SEQ_PATH_1, prefix="abc_")

--- a/ezfastq/tests/test_copier.py
+++ b/ezfastq/tests/test_copier.py
@@ -86,10 +86,11 @@ def test_copier_link_error(tmp_path):
 
 
 def test_copier_exclusion(tmp_path):
-    sample_names = NameMap.from_arglist(["test1", "test2"])
-    copier = FastqCopier.from_dir(sample_names, SEQ_PATH_1, link=True, excl_pattern="R2")
+    sample_names = NameMap.from_arglist(["test1", "test2", "test3"])
+    copier = FastqCopier.from_dir(sample_names, SEQ_PATH_1, excl_pattern="[R,r]2")
+    assert len(copier) == 3
     copier.copy_files(tmp_path)
-    assert len(list(tmp_path.glob("*.fastq.gz"))) == 2
+    assert len(list(tmp_path.glob("*.fastq.gz"))) == 3
 
 
 def test_copier_prefix(tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezfastq"
-version = "0.2"
+version = "0.2.1.dev"
 description = "Scan directories for FASTQ files and associate with sample names"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezfastq"
-version = "0.2.1.dev"
+version = "0.3"
 description = "Scan directories for FASTQ files and associate with sample names"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR adds a new feature that skips copying for user-specified FASTQ files. It doesn't affect the initial FASTQ file *discovery* stage: if, for instance, `ezfastq` is expecting paired-end data, it will still fail if more or less than two FASTQ files are found for any sample. But after successful discovery, the new feature will skip copying for files matching the user-specified exclusion pattern (typically something like "R2").

<small>Pair programming with @danejo3</small>