### PR TITLE
Extraneous Lines in `samples.txt` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fixed bug where `samples.txt` would have extraneous empty lines if `ezfastq` was run multiple times with the same samples (#12)
+- Fixed bug involving reading and writing empty lines from `samples.txt` file (#12)
 
 ## [0.2] 2025-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed bug where `samples.txt` would have extraneous empty lines if `ezfastq` was run multiple times with the same samples (#12)
 
 ## [0.2] 2025-12-15
 

--- a/ezfastq/api.py
+++ b/ezfastq/api.py
@@ -35,6 +35,7 @@ def copy(
         print(log, file=fh)
     added_samples = set(fastq.sample for fastq in copier.copied_files)
     added_samples = sorted(added_samples)
-    with open(workdir / "samples.txt", "a") as fh:
-        print(*added_samples, sep="\n", file=fh)
+    if len(added_samples) > 0:
+        with open(workdir / "samples.txt", "a") as fh:
+            print(*added_samples, sep="\n", file=fh)
     return copier

--- a/ezfastq/namemap.py
+++ b/ezfastq/namemap.py
@@ -22,8 +22,9 @@ class NameMap(dict):
         name_map = cls()
         with open(path, "r") as fh:
             for line in fh:
-                old_name, new_name = cls.parse_name(line, sep="\t")
-                name_map[old_name] = new_name
+                if line.strip():
+                    old_name, new_name = cls.parse_name(line, sep="\t")
+                    name_map[old_name] = new_name
         if len(name_map) == 0:
             raise ValueError(f'sample name file "{path}" is empty')
         return name_map

--- a/ezfastq/tests/test_cli.py
+++ b/ezfastq/tests/test_cli.py
@@ -86,3 +86,16 @@ def test_fq_command(tmp_path):
     arglist = ["ezfastq", seq_path, "test1", "test2", "test3", "--workdir", tmp_path]
     run(arglist)
     assert len(list((tmp_path / "seq").glob("*_R?.fastq.gz"))) == 6
+
+
+def test_duplicate_samples(tmp_path):
+    seq_path = files("ezfastq") / "tests" / "data" / "flat"
+    arglist = [seq_path, "test1", "test2", "test3", "--workdir", tmp_path]
+    cli.main(arglist)
+    with open(tmp_path / "samples.txt", "r") as fh:
+        num_lines = len(fh.readlines())
+        assert num_lines == 3
+    cli.main(arglist)
+    with open(tmp_path / "samples.txt", "r") as fh:
+        num_lines = len(fh.readlines())
+        assert num_lines == 3

--- a/ezfastq/tests/test_cli.py
+++ b/ezfastq/tests/test_cli.py
@@ -67,9 +67,10 @@ def test_copy_subdir(tmp_path):
     assert len(list(rundir.glob("*_R?.fastq.gz"))) == 4
 
 
-def test_copy_sample_names_file(tmp_path):
+@pytest.mark.parametrize("samples", ["test1\ntest3\ntest2\n", "test1\ntest3\ntest2\n\n\n\n"])
+def test_copy_sample_names_file(samples, tmp_path):
     sample_names_file = tmp_path / "sample-names.txt"
-    sample_names_file.write_text("test1\ntest3\ntest2\n")
+    sample_names_file.write_text(samples)
     seq_path = files("ezfastq") / "tests" / "data" / "nested"
     arglist = [seq_path, sample_names_file, "--workdir", tmp_path]
     cli.main(arglist)


### PR DESCRIPTION
This PR fixes a bug recently encountered.

When running `ezfastq` a `samples.txt` file will automatically be generated for the user containing the sample names of all the files that have been copied over. `ezfastq` will append sample names to this file rather than overwrite it if `ezfastq` is ran multiple times with the same working directory. `ezfastq` avoids writing duplicate sample names to the `samples.txt` file. However, if `ezfastq` is ran multiple times with the same samples, empty lines will be appended to the file. 

Closes #12 